### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/SLIIT-Y3S1/6af1d574-43c2-4757-a687-e53a4e849872/85c2c4ed-31d9-4270-97ae-7c5a220b2f1d/_apis/work/boardbadge/2166ceaf-2f28-443a-9754-a884bb602f02)](https://dev.azure.com/SLIIT-Y3S1/6af1d574-43c2-4757-a687-e53a4e849872/_boards/board/t/85c2c4ed-31d9-4270-97ae-7c5a220b2f1d/Microsoft.RequirementCategory)
 # spm-backend
 _Backend repository for SPM Project_
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/SLIIT-Y3S1/6af1d574-43c2-4757-a687-e53a4e849872/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.